### PR TITLE
Update MavenPhantomJSBinaryResolver.java

### DIFF
--- a/src/main/java/org/jboss/arquillian/phantom/resolver/maven/MavenPhantomJSBinaryResolver.java
+++ b/src/main/java/org/jboss/arquillian/phantom/resolver/maven/MavenPhantomJSBinaryResolver.java
@@ -40,7 +40,7 @@ public class MavenPhantomJSBinaryResolver implements PhantomJSBinaryResolver {
     @Override
     public PhantomJSBinary resolve(File destination) throws IOException {
         File realDestination = destination.isDirectory() ? new File(destination, PHANTOMJS) : destination;
-        if (realDestination.exists() && realDestination.canExecute()) {
+        if (realDestination.exists() && realDestination.length() > 0 && realDestination.canExecute()) {
             return new PhantomJSBinary(realDestination);
         }
         return resolveFreshExtracted(realDestination);


### PR DESCRIPTION
Test testSimple() in TestDriver currently fails on Windows.
Problem: If no path is provided the created file has 0 bytes but is executable.
