### PR TITLE
Support for path names with spaces in Unix environments

### DIFF
--- a/src/main/java/org/jboss/arquillian/phantom/resolver/FileUtils.java
+++ b/src/main/java/org/jboss/arquillian/phantom/resolver/FileUtils.java
@@ -56,7 +56,12 @@ public class FileUtils {
     public static void setExecutable(File file) throws IOException {
         if (isUnix()) {
             try {
-                Runtime.getRuntime().exec("chmod +x " + file.getAbsolutePath()).waitFor();
+                ProcessBuilder pb = new ProcessBuilder("chmod", "+x", file.getAbsolutePath());
+                int exitCode = pb.start().waitFor();
+                if (exitCode != 0) {
+                    throw new IOException("Unable to set executable flag on " + file.getAbsolutePath()
+                       + ". Exit code was " + exitCode);
+                }
             } catch (InterruptedException ex) {
                 Logger.getLogger(FileUtils.class.getName()).log(Level.SEVERE, null, ex);
             }

--- a/src/test/java/org/jboss/arquillian/phantom/resolver/TestMavenResolver.java
+++ b/src/test/java/org/jboss/arquillian/phantom/resolver/TestMavenResolver.java
@@ -1,9 +1,5 @@
 package org.jboss.arquillian.phantom.resolver;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -12,6 +8,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.os.CommandLine;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class TestMavenResolver {
 
@@ -33,6 +32,13 @@ public class TestMavenResolver {
         File location = binary.getLocation();
 
         assertTrue(location.exists());
+    }
+
+    @Test
+    public void testIsExecutable() throws IOException {
+        PhantomJSBinary binary = resolver.resolve(new File("target/folder with spaces/testExecutable-phantomjs"));
+        File location = binary.getLocation();
+        assertTrue(location.canExecute());
     }
 
     @Test


### PR DESCRIPTION
This pull request fixes 
https://github.com/qa/arquillian-phantom-driver/issues/7
I created also a test, to validate the correct behaviour.
