### PR TITLE
Deps upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
     <properties>
         <!-- versions -->
         <selenium.version>2.43.1</selenium.version>
-        <phantomjs.driver.version>1.2.0</phantomjs.driver.version>
+        <phantomjs.driver.version>1.2.1</phantomjs.driver.version>
         <junit.version>4.11</junit.version>
         <shrinkwrap.resolver.version>2.1.1</shrinkwrap.resolver.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>com.github.detro</groupId>
+            <groupId>com.codeborne</groupId>
             <artifactId>phantomjsdriver</artifactId>
             <version>${phantomjs.driver.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <!-- versions -->
-        <selenium.version>2.43.1</selenium.version>
+        <selenium.version>2.45.0</selenium.version>
         <phantomjs.driver.version>1.2.1</phantomjs.driver.version>
         <junit.version>4.11</junit.version>
         <shrinkwrap.resolver.version>2.1.1</shrinkwrap.resolver.version>


### PR DESCRIPTION
PhantomJS driver 1.2.0 doesn't work with Selenium 2.44+. Selenium and PhantomJS driver upgraded (different groupId because original maintainer not responding anymore).