### PR TITLE
Update versions & removed useless property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 
     <properties>
         <!-- versions -->
-        <selenium.version>2.45.0</selenium.version>
         <phantomjs.driver.version>1.2.1</phantomjs.driver.version>
         <junit.version>4.11</junit.version>
         <shrinkwrap.resolver.version>2.1.1</shrinkwrap.resolver.version>


### PR DESCRIPTION
updated to jboss-parent 19 and junit 4.12
removed useless selenium.version property