### PR TITLE
Added possibility to set command-line options by capabilities

### DIFF
--- a/src/main/java/org/jboss/arquillian/phantom/resolver/ResolvingPhantomJSDriverService.java
+++ b/src/main/java/org/jboss/arquillian/phantom/resolver/ResolvingPhantomJSDriverService.java
@@ -4,14 +4,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.os.CommandLine;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.service.DriverService;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 public class ResolvingPhantomJSDriverService extends DriverService {
 
@@ -54,7 +53,30 @@ public class ResolvingPhantomJSDriverService extends DriverService {
         DesiredCapabilities newCapabilities = new DesiredCapabilities(capabilities);
         newCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY, binary.getLocation()
                 .getAbsolutePath());
+        reformatCLIArgumentsInCapToArray(newCapabilities);
+
         return PhantomJSDriverService.createDefaultService(newCapabilities);
+    }
+
+    /**
+     * Reformats {@link PhantomJSDriverService.PHANTOMJS_CLI_ARGS} and
+     * {@link PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS} from String to String[]
+     *
+     * @param capabilities Capabilities
+     */
+    protected static void reformatCLIArgumentsInCapToArray(DesiredCapabilities capabilities){
+        reformatCapabilityToArray(capabilities, PhantomJSDriverService.PHANTOMJS_CLI_ARGS);
+        reformatCapabilityToArray(capabilities, PhantomJSDriverService.PHANTOMJS_GHOSTDRIVER_CLI_ARGS);
+    }
+
+    private static void reformatCapabilityToArray(DesiredCapabilities capabilities, String capabilityName){
+        Object capability = capabilities.getCapability(capabilityName);
+        if (capability != null) {
+            if (capability instanceof String){
+                String[] splitArgs = ((String) capability).split(" ");
+                capabilities.setCapability(capabilityName, splitArgs);
+            }
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/src/test/java/org/jboss/arquillian/phantom/resolver/TestMavenResolver.java
+++ b/src/test/java/org/jboss/arquillian/phantom/resolver/TestMavenResolver.java
@@ -8,6 +8,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.os.CommandLine;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -72,6 +74,23 @@ public class TestMavenResolver {
         // when
         File location = resolver.resolve(new File("target/testVersion-phantomjs")).deleteOnExit().getLocation();
         CommandLine cmd = new CommandLine(location.getAbsolutePath(), new String[] { "--version" });
+        cmd.execute();
+
+        // then
+        assertThat(cmd.getStdOut(), containsString(ResolverConfiguration.DEFAULT_PHANTOMJS_BINARY_VERSION));
+    }
+
+    @Test
+    public void testReformatCLIArgumentsInCapToArray() throws IOException {
+        // given
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, "--version");
+        ResolvingPhantomJSDriverService.reformatCLIArgumentsInCapToArray(capabilities);
+
+        // when
+        File location = resolver.resolve(new File("target/testVersion-phantomjs")).deleteOnExit().getLocation();
+        CommandLine cmd = new CommandLine(location.getAbsolutePath(), (String[]) capabilities.getCapability(
+            PhantomJSDriverService.PHANTOMJS_CLI_ARGS));
         cmd.execute();
 
         // then


### PR DESCRIPTION
With this fix it is possible to set command-line options there in arquillian.xml; eg:
<property name="phantomjs.cli.args">--ignore-ssl-errors=true --web-security=false</property>